### PR TITLE
Fix tests compile error

### DIFF
--- a/KeychainTests/KeychainTests.swift
+++ b/KeychainTests/KeychainTests.swift
@@ -41,7 +41,7 @@ class KeychainTests: XCTestCase {
         query[kSecReturnAttributes as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitAll
 
-        let result: AnyObject? = Keychain.find(query)
+        let result: KeychainQueryResult = Keychain.find(query)
     }
 
 }


### PR DESCRIPTION
The tests don't compile with an error:

```
KeychainTests/KeychainTests.swift:44:43: 'KeychainQueryResult' is not convertible to 'AnyObject?'
```

This makes them compile at least.
